### PR TITLE
Fix string replacement when filtering countries

### DIFF
--- a/Sources/CountryPicker/CountryPickerViewController.swift
+++ b/Sources/CountryPicker/CountryPickerViewController.swift
@@ -248,8 +248,8 @@ extension CountryPickerViewController: UITextFieldDelegate {
     public func textField(
         _ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String
     ) -> Bool {
-        guard let text = textField.text else { return true }
-        let finalText = NSString(string: text).replacingOccurrences(of: text, with: string, range: range)
+        guard let text = textField.text, let textRange = Range(range, in: text) else { return true }
+        let finalText = text.replacingCharacters(in: textRange, with: string)
         filter(for: finalText)
         return true
     }


### PR DESCRIPTION
Following the changes in PR #14, text filtering doesn't account for the latest edit, as the method for updating the string with it is currently incorrect. Instead of replacing the string at the given range with the latest edit, it will look for `text` in `range` and replace it with `string` (and the complete `text` probably never appears in `range`, which represents a substring of `text`):

https://github.com/mobven/CountryPicker/blob/251706ac6b4143dd7218b8c541874af32239e351/Sources/CountryPicker/CountryPickerViewController.swift#L252

The wanted behavior here is to simply replace a range of the receiver string with another string (the latest edit). This pull request fixes this issue without using an `NSString`.

And btw, thanks for this simple and useful library 🙂