### PR TITLE
Added bool on config to hide phone codes

### DIFF
--- a/Sources/CountryPicker/Config.swift
+++ b/Sources/CountryPicker/Config.swift
@@ -33,6 +33,7 @@ public protocol Configuration {
     var searchBarClearImage: UIImage? { get set }
     var searchBarCornerRadius: CGFloat { get set }
     var separatorColor: UIColor { get set }
+    var showPhoneCodes: Bool { get set }
 }
 
 public struct Config: Configuration {
@@ -99,6 +100,9 @@ public struct Config: Configuration {
     
     /// background color of separatorView
     public var separatorColor: UIColor
+    
+    /// show /  hide phone numbers
+    public var showPhoneCodes: Bool
 
     public init(
         countryNameTextColor: UIColor = ColorCompatibility.label,
@@ -121,7 +125,8 @@ public struct Config: Configuration {
         searchBarLeftImage: UIImage? = nil,
         searchBarClearImage: UIImage? = nil,
         searchBarCornerRadius: CGFloat = 4,
-        separatorColor: UIColor = ColorCompatibility.systemGray5
+        separatorColor: UIColor = ColorCompatibility.systemGray5,
+        showPhoneCodes: Bool = true
     ) {
         self.countryNameTextColor = countryNameTextColor
         self.countryNameTextFont = countryNameTextFont
@@ -144,5 +149,6 @@ public struct Config: Configuration {
         self.searchBarClearImage = searchBarClearImage
         self.searchBarCornerRadius = searchBarCornerRadius
         self.separatorColor = separatorColor
+        self.showPhoneCodes = showPhoneCodes
     }
 }

--- a/Sources/CountryPicker/CountryPickerCell.swift
+++ b/Sources/CountryPicker/CountryPickerCell.swift
@@ -57,30 +57,35 @@ public final class CountryPickerCell: UITableViewCell {
 
     func setupViews() {
         contentView.addSubview(stackView)
-        stackView.addArrangedSubviews(
-            countryNameLabel,
-            countryCodeContainerView
-        )
-        countryCodeContainerView.addSubview(countryCodeLabel)
+                
+        stackView.addArrangedSubview(countryNameLabel)
+
+        if CountryManager.shared.config.showPhoneCodes {
+            stackView.addArrangedSubview(countryCodeContainerView)
+            countryCodeContainerView.addSubview(countryCodeLabel)
+        }
     }
 
     func setupLayouts() {
         stackView.translatesAutoresizingMaskIntoConstraints = false
-        countryCodeContainerView.translatesAutoresizingMaskIntoConstraints = false
-        countryNameLabel.translatesAutoresizingMaskIntoConstraints = false
-        countryCodeLabel.translatesAutoresizingMaskIntoConstraints = false
-
-        countryCodeLabel.setContentHuggingPriority(.required, for: .horizontal)
-        countryCodeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
-
-        countryCodeLabel.leadingAnchor.constraint(equalTo: countryCodeContainerView.leadingAnchor, constant: 6)
-            .isActive = true
-        countryCodeLabel.trailingAnchor.constraint(equalTo: countryCodeContainerView.trailingAnchor, constant: -8)
-            .isActive = true
-        countryCodeLabel.topAnchor.constraint(equalTo: countryCodeContainerView.topAnchor, constant: 3).isActive = true
-        countryCodeLabel.bottomAnchor.constraint(equalTo: countryCodeContainerView.bottomAnchor, constant: -3)
-            .isActive = true
-
+        
+        if CountryManager.shared.config.showPhoneCodes {
+            countryCodeContainerView.translatesAutoresizingMaskIntoConstraints = false
+            countryNameLabel.translatesAutoresizingMaskIntoConstraints = false
+            countryCodeLabel.translatesAutoresizingMaskIntoConstraints = false
+            
+            countryCodeLabel.setContentHuggingPriority(.required, for: .horizontal)
+            countryCodeLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+            
+            countryCodeLabel.leadingAnchor.constraint(equalTo: countryCodeContainerView.leadingAnchor, constant: 6)
+                .isActive = true
+            countryCodeLabel.trailingAnchor.constraint(equalTo: countryCodeContainerView.trailingAnchor, constant: -8)
+                .isActive = true
+            countryCodeLabel.topAnchor.constraint(equalTo: countryCodeContainerView.topAnchor, constant: 3).isActive = true
+            countryCodeLabel.bottomAnchor.constraint(equalTo: countryCodeContainerView.bottomAnchor, constant: -3)
+                .isActive = true
+        }
+        
         stackView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor, constant: 20).isActive = true
         stackView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -20).isActive = true
         stackView.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 12).isActive = true


### PR DESCRIPTION
- Added boolean config for hiding / showing phone codes
- By default ( and in order to keep backwards compatibility) the flag is set to true - to show phone codes
![Simulator Screenshot - iPhone 14 Pro - 2023-04-02 at 03 01 44](https://user-images.githubusercontent.com/102022562/229347764-ad8e3377-c678-41d0-8f6d-3b53ac0a3f51.png)
